### PR TITLE
Python test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ elseif(BUILD_LINUX)
 
 	if(PYTHON_TEST)
 		target_link_libraries(${CMAKE_PROJECT_NAME}
-			python27
+			python2.7
 		)
 	endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,23 @@ if(HEADER_WITH_JSONCPP)
 	add_definitions(-DHeader_Jsoncpp)
 endif()
 
+set(PYTHON_TEST OFF CACHE BOOL "If on, build will include early Python tests and some parts of the game will activate it")
+if(PYTHON_TEST)
+	add_definitions(-DPython_Test)
+	message(STATUS "Building with Python support")
+endif()
+
 if(BUILD_WINDOWS)
 	message(STATUS "Building for Windows")
 	add_definitions(-DWindows)
 
 	set(BUILD_WINDOWS_PKGS "C:/Users/Hamme/pkgs" CACHE STRING "Path to the packages, only for Windows")
 
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -pthread -std=c++17 -Wl,-subsystem,windows")
+	if(PYTHON_TEST)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -pthread -std=c++17 -DMS_WIN64")
+	else()
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -pthread -std=c++17 -Wl,-subsystem,windows")
+	endif()
 
 	project(Sand-Box2D)
 
@@ -49,6 +59,12 @@ if(BUILD_WINDOWS)
 		SDL2
 	)
 
+	if(PYTHON_TEST)
+		target_link_libraries(${CMAKE_PROJECT_NAME}
+			python27
+		)
+	endif()
+
 	file(COPY assets DESTINATION .)
 
 elseif(BUILD_LINUX)
@@ -72,6 +88,12 @@ elseif(BUILD_LINUX)
 		SDL2
 	)
 
+	if(PYTHON_TEST)
+		target_link_libraries(${CMAKE_PROJECT_NAME}
+			python27
+		)
+	endif()
+
 	file(COPY assets DESTINATION .)
 
 elseif(BUILD_VITA)
@@ -79,11 +101,11 @@ elseif(BUILD_VITA)
 	add_definitions(-DVita)
 
 	if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-	  if(DEFINED ENV{VITASDK})
-		set(CMAKE_TOOLCHAIN_FILE "$ENV{VITASDK}/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
-	  else()
-		message(FATAL_ERROR "Please define VITASDK to point to your SDK path!")
-	  endif()
+		if(DEFINED ENV{VITASDK})
+			set(CMAKE_TOOLCHAIN_FILE "$ENV{VITASDK}/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
+		else()
+			message(FATAL_ERROR "Please define VITASDK to point to your SDK path!")
+	  	endif()
 	endif()
 
 	project(Sand-Box2D C CXX)
@@ -127,10 +149,6 @@ elseif(BUILD_VITA)
 		z
 		freetype
 
-		python2.7
-		m
-		intl
-
 		SceAudio_stub
 		SceAudioIn_stub
 		SceCommonDialog_stub
@@ -142,6 +160,14 @@ elseif(BUILD_VITA)
 		SceTouch_stub
 		SceMotion_stub
 	)
+
+	if(PYTHON_TEST)
+		target_link_libraries(${CMAKE_PROJECT_NAME}
+			python2.7
+			m
+			intl
+		)
+	endif()
 
 	vita_create_self(${CMAKE_PROJECT_NAME}.self ${CMAKE_PROJECT_NAME})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,9 @@ if(BUILD_WINDOWS)
 		target_link_libraries(${CMAKE_PROJECT_NAME}
 			python27
 		)
+		# message(STATUS "Copying pylibs dir, this may take a while...")
+		# file(COPY "${BUILD_WINDOWS_PKGS}/pylibs" DESTINATION .)
+		# message(STATUS "Pylibs dir copied!")
 	endif()
 
 	file(COPY assets DESTINATION .)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ If you don't want to build by yourself, you can consider auto build system provi
   * [SDL2_gfx](https://www.ferzkopp.net/wordpress/2016/01/02/sdl_gfx-sdl2_gfx/);
   * [Box2D](https://github.com/erincatto/box2d);
   * [jsoncpp](https://github.com/open-source-parsers/jsoncpp);
-  * [libcurl](https://github.com/curl/curl).
+  * [cURL](https://github.com/curl/curl);
+  * And [Python 2.7](https://www.python.org/downloads/release/python-2716/) if you want to run early tests.
 - Or simply just unpack contents of [this](https://github.com/Hammerill/Sand-Box2D/releases/download/v1.0.0/win64-packages.zip) archive somewhere. 
 - Also, you have to add "bin" directory (located where the packages are installed) to your PATH variable,
 or copy its contents (*.dll) to the same directory where .exe file should be (build).
@@ -133,8 +134,14 @@ If you experience errors with Jsoncpp library while building try to disable `HEA
   make
   ```
 
+If you want to build with experimental Python 2.7 support run it:
+  ```
+  cmake .. -DPYTHON_TEST=ON
+  make
+  ```
+
 ### On Linux
-1. Install following libraries somehow with your package manager:
+1. Install following libraries somehow with your package manager (possible string `sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_gfx box2d jsoncpp curl python2.7`):
 - SDL2;
 - SDL2_image;
 - SDL2_mixer;
@@ -142,7 +149,8 @@ If you experience errors with Jsoncpp library while building try to disable `HEA
 - SDL2_gfx;
 - Box2D;
 - jsoncpp;
-- libcurl.
+- cURL;
+- And Python 2.7 if you want to run early tests.
 2. Clone repo:
   ```bash
   git clone https://github.com/Hammerill/Sand-Box2D && cd Sand-Box2D
@@ -162,6 +170,12 @@ If you experience errors with Jsoncpp library while building try to disable `HEA
 If you experience errors with Jsoncpp library while building try to disable `HEADER_WITH_JSONCPP` flag via this:
   ```
   cmake .. -DHEADER_WITH_JSONCPP=OFF
+  make -j4
+  ```
+
+If you want to build with experimental Python 2.7 support run it:
+  ```
+  cmake .. -DPYTHON_TEST=ON
   make -j4
   ```
 

--- a/assets/scripts/example.py
+++ b/assets/scripts/example.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+import box2d
+
+box2d.sound()

--- a/assets/scripts/example.py
+++ b/assets/scripts/example.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-import box2d
+import sandbox2d
 
-box2d.sound()
+sandbox2d.sound()

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -5,6 +5,15 @@ bool vita_inited_video = false;
 #else
 bool vita_inited_video = true;
 #endif
+    
+static PyObject* fun(PyObject* self, PyObject* args)
+{
+    std::cout << "I can't." << std::endl;
+    return NULL;
+}
+static PyMethodDef Box2DMethods[] = {
+    {"sound", fun, 0, "Play SFX."}
+};
 
 GameManager::GameManager(const char* path_to_settings, const char* path_to_def_settings)
 {
@@ -111,7 +120,7 @@ bool GameManager::Step()
                     key = true;
                     current_visual = LANG_SELECTOR_VISUAL;
                 }
-#if PYTHON_TEST
+#if Python_Test
                 else if (GameManager::main_menu.GetStatus() == "level_editor")
                 {
                     Py_NoSiteFlag = 1;
@@ -119,8 +128,10 @@ bool GameManager::Step()
                     Py_NoUserSiteDirectory = 1;
 
                     Py_SetProgramName("Sand-Box2D");
-                    Py_InitializeEx(1);
-                    PyRun_SimpleString("print('qqepta')");
+                    Py_InitializeEx(0);
+                    Py_InitModule3("box2d", Box2DMethods, NULL);
+                    PyObject* PyFileObject = PyFile_FromString("./assets/scripts/example.py", "r");
+                    PyRun_SimpleFile(PyFile_AsFile(PyFileObject), "example.py");
                     Py_Finalize();
 
                     GameManager::main_menu.Init(GameManager::rr);

--- a/src/GameManager.h
+++ b/src/GameManager.h
@@ -8,11 +8,8 @@
 #include "Screens/WorldManager.h"
 #include "Screens/LangSelector.h"
 
-#ifdef Vita
-#define PYTHON_TEST 0
-#if PYTHON_TEST
-#include <python2.7/Python.h>
-#endif
+#ifdef Python_Test
+#include "System/Python.h"
 #endif
 
 /// @brief Which single class is responsible for the entire screen?

--- a/src/GameManager.h
+++ b/src/GameManager.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef Python_Test
+#include "System/Python.h"
+#endif
+
 #include "System/Renderer.h"
 #include "System/Controls.h"
 #include "System/Settings.h"
@@ -7,10 +11,6 @@
 #include "Screens/MainMenu.h"
 #include "Screens/WorldManager.h"
 #include "Screens/LangSelector.h"
-
-#ifdef Python_Test
-#include "System/Python.h"
-#endif
 
 /// @brief Which single class is responsible for the entire screen?
 enum CurrentVisual

--- a/src/System/Python.h
+++ b/src/System/Python.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#if defined(Windows)
+#include <python2.7/Python.h>
+#elif defined(Linux)
+
+// If you came here because of compile error sorry lol.
+// If you aren't able to find where is your installed Python 2.7 located and to change this path here
+// just disable PYTHON_TEST flag in CMake (and you DO know how to do it if you enabled it right?).
+#include <python2.7/Python.h>
+
+#elif defined(Vita)
+#include <python2.7/Python.h>
+#endif


### PR DESCRIPTION
# Early experimental Python 2.7 support test.

When you click on `LEVEL EDITOR`, Sand-Box2D will run `./scripts/example.py` which will import generated Python module that was hardcoded in the GameManager. This script will call `sound()` function from it which will play a loud noise, then MainMenu would be reinitialized.

Currently tested on all the official platforms: Windows, Linux and PS Vita.